### PR TITLE
Feature init sheets

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -133,6 +133,58 @@ class SlackClient {
  * @param {string} token Slackアプリトークン
  * @return {SlackClient}
  */
-function init(token) {
+const init = (token) => {
   return new SlackClient(token);
+};
+
+/**
+ * オブジェクト配列をテーブル配列に変換
+ * @param {Array} obj オブジェクト配列
+ * @return {Array} テーブル化された配列
+ */
+const object2Table = (obj) => {
+  const headers = [Object.keys(obj[0])];
+  const body = obj.map((e) => Object.values(e));
+  const table = headers.concat(body);
+
+  return table;
+};
+
+/**
+ * テーブル配列をオブジェクト配列に変換
+ * @param {Array} table テーブル配列
+ * @return {Array} オブジェクト化された配列
+ */
+const table2Object = (table) => {
+  const arry = [];
+  for (let i = 1; i < table.length; i++) {
+    const obj = {};
+    for (let ii = 0; ii < table[i].length; ii++) {
+      obj[table[0][ii]] = table[i][ii];
+    }
+    arry.push(obj);
+  }
+  return arry;
+};
+
+/**
+ * ネストされたオブジェクトをフラットにする
+ * @param {Object} obj ネストされたオブジェクト
+ * @return {Object} フラット化されたオブジェクト
+ */
+const flattenObj = (obj) => {
+  const result = {};
+  for (const key in obj) {
+    const value = obj[key];
+    if (typeof value === "object") {
+      const flatObj = flattenObj(value);
+      for (const subKey in flatObj) {
+        result[`${key}.${subKey}`] = flatObj[subKey];
+      }
+    } else {
+      result[key] = value;
+    }
 }
+
+  return result;
+};

--- a/src/main.js
+++ b/src/main.js
@@ -126,6 +126,52 @@ class SlackClient {
     };
     return this.request("post", api_method, payload);
   }
+
+  /**
+   * スプレッドシートに管理用シートを生成
+   * @param {Sheet} sheet 初期化対象シート
+   * @param {Array} fields 取得対象フィールドを限定する場合は配列でkeyを指定
+   */
+  initUsersSheet(sheetName = "users", fields) {
+    const sheet =
+      spreadSheet.getSheetByName(sheetName) ||
+      spreadSheet.insertSheet(sheetName);
+    sheet.clearContents();
+
+    const json = slack.getUsers();
+
+    const flatJson = json.map((e) => flattenObj(e));
+    const headers = fields || Object.keys(flatJson[0]);
+    const body = flatJson.map((row) => {
+      return headers.map((key) => row[key] || "");
+    });
+
+    const table = [headers].concat(body);
+    sheet.getRange(1, 1, table.length, table[0].length).setValues(table);
+  }
+
+  /**
+   * スプレッドシートに管理用シートを生成
+   * @param {Sheet} sheet 初期化対象シート
+   * @param {Array} fields 取得対象フィールドを限定する場合は配列でkeyを指定
+   */
+  initChannelsSheet(sheetName = "channels", fields) {
+    const sheet =
+      spreadSheet.getSheetByName(sheetName) ||
+      spreadSheet.insertSheet(sheetName);
+    sheet.clearContents();
+
+    const json = slack.getChannels();
+
+    const flatJson = json.map((e) => flattenObj(e));
+    const headers = fields || Object.keys(flatJson[0]);
+    const body = flatJson.map((row) => {
+      return headers.map((key) => row[key] || "");
+    });
+
+    const table = [headers].concat(body);
+    sheet.getRange(1, 1, table.length, table[0].length).setValues(table);
+  }
 } // end class SlackAPI
 
 /**
@@ -184,7 +230,7 @@ const flattenObj = (obj) => {
     } else {
       result[key] = value;
     }
-}
+  }
 
   return result;
 };

--- a/src/main.js
+++ b/src/main.js
@@ -133,6 +133,7 @@ class SlackClient {
    * @param {Array} fields 取得対象フィールドを限定する場合は配列でkeyを指定
    */
   initUsersSheet(sheetName = "users", fields) {
+    const spreadSheet = SpreadsheetApp.getActiveSpreadsheet();
     const sheet =
       spreadSheet.getSheetByName(sheetName) ||
       spreadSheet.insertSheet(sheetName);
@@ -156,6 +157,7 @@ class SlackClient {
    * @param {Array} fields 取得対象フィールドを限定する場合は配列でkeyを指定
    */
   initChannelsSheet(sheetName = "channels", fields) {
+    const spreadSheet = SpreadsheetApp.getActiveSpreadsheet();
     const sheet =
       spreadSheet.getSheetByName(sheetName) ||
       spreadSheet.insertSheet(sheetName);


### PR DESCRIPTION
スプレッドシートに全ユーザー、全チャンネル情報を展開するシートを生成する。

```javascript
  /**
   * スプレッドシートに管理用シートを生成
   * @param {Sheet} sheet 初期化対象シート
   * @param {Array} fields 取得対象フィールドを限定する場合は配列でkeyを指定
   */
  initUsersSheet(sheetName = "users", fields) 
```

```javascript
  /**
   * スプレッドシートに管理用シートを生成
   * @param {Sheet} sheet 初期化対象シート
   * @param {Array} fields 取得対象フィールドを限定する場合は配列でkeyを指定
   */
  initChannelsSheet(sheetName = "channels", fields) 
```

![image](https://user-images.githubusercontent.com/15005576/122680559-b316b000-d22a-11eb-9f1e-897394452a07.png)
